### PR TITLE
Update fastapi-xml to 1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "pynacl==1.5.0",
         "dnspython==2.6.1",
         "fastapi>=0.110,<=0.113",
-        "fastapi-xml==1.1.0",
+        "fastapi-xml>=1.1.1,<2.0.0",
         "requests",
         "uvicorn",
         "termcolor",


### PR DESCRIPTION
Current version of fastapi supported by this package is not compatible with pinned version of fastapi-xml.
This fixes it, while also adding support for any non breaking change coming from fastapi-xml in the future